### PR TITLE
Fix changeset version command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Create release PR or publish
         uses: changesets/action@v1
         with:
-          version: npx changeset version && npm install --package-lock-only
+          version: sh -c 'npx changeset version && npm install --package-lock-only'
           publish: npx changeset publish --provenance
           title: "chore: version packages"
           commit: "chore: version packages"


### PR DESCRIPTION
The `changesets/action` `version` input passes the entire string as arguments to `changeset`, so `&&` chaining doesn't work. Wraps in `sh -c` so the lockfile update runs after versioning.

**Error from CI:**
```
🦋 error Too many arguments passed to changesets - we only accept the command name as an argument
```