### PR TITLE
Fix changeset version shell quoting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Create release PR or publish
         uses: changesets/action@v1
         with:
-          version: sh -c 'npx changeset version && npm install --package-lock-only'
+          version: npm run version-packages
           publish: npx changeset publish --provenance
           title: "chore: version packages"
           commit: "chore: version packages"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "tsc": "tsc -b packages/storybook-addon-performance-panel/tsconfig.build.json",
     "docs": "npm run build && npm run storybook -w @github-ui/docs",
     "docs:build": "npm run build && npm run build-storybook -w @github-ui/docs",
-    "changeset": "changeset"
+    "changeset": "changeset",
+    "version-packages": "changeset version && npm install --package-lock-only"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
The `changesets/action` executes the `version` input via `sh -c`, so wrapping in `sh -c '...'` caused nested quoting errors:

```
changeset: 1: Syntax error: Unterminated quoted string
```

Fix: move the command chain into an npm script (`version-packages`) to avoid shell quoting issues entirely.