### PR TITLE
fix: OIDC npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
 
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   pull-requests: write
@@ -21,8 +23,8 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          registry-url: https://registry.npmjs.org
-          scope: '@github-ui'
+      - name: Update npm
+        run: npm update -g npm
       - run: npm ci
       - run: npm run build
       - name: Create release PR or publish
@@ -30,11 +32,13 @@ jobs:
         uses: changesets/action@v1
         with:
           version: npm run version-packages
-          publish: npx changeset publish --provenance
+          publish: npx changeset publish
           title: "chore: version packages"
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ''
+          NPM_CONFIG_PROVENANCE: true
       - name: Report CI status on changeset PR
         if: steps.changesets.outputs.pullRequestNumber
         env:

--- a/packages/storybook-addon-performance-panel/package.json
+++ b/packages/storybook-addon-performance-panel/package.json
@@ -11,6 +11,10 @@
     "url": "https://github.com/github/storybook-addon-performance-panel.git",
     "directory": "packages/storybook-addon-performance-panel"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "keywords": [
     "storybook",
     "storybook-addon",


### PR DESCRIPTION
## Changes

- Add `publishConfig` with `access: public` and `registry` to package.json (required for scoped packages)
- Use `NPM_CONFIG_PROVENANCE: true` env var instead of `--provenance` CLI flag
- Set `NPM_TOKEN: ''` to enable OIDC token exchange in changesets action
- Add `npm update -g npm` step for latest OIDC support
- Add `concurrency` group to prevent parallel release runs

Previous publish attempts failed with E404 because:
1. Missing `publishConfig.access: public` for the scoped `@github-ui` package
2. `--provenance` CLI flag wasn't propagating correctly through changesets
3. OIDC token exchange needed explicit empty `NPM_TOKEN`