### PR TITLE
chore: optimize devcontainer for prebuilds and add canary releases

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,5 +12,6 @@
       "onAutoForward": "notify"
     }
   },
-  "postCreateCommand": "npm install"
+  "onCreateCommand": "npm install && npx playwright install --with-deps",
+  "updateContentCommand": "npm install"
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,9 @@ name: Release
 on:
   push:
     branches: [main]
-
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: write
@@ -15,8 +16,12 @@ permissions:
 jobs:
   release:
     name: Release
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: production
+    concurrency:
+      group: release-production
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -49,3 +54,87 @@ jobs:
             -f state=success \
             -f context=CI \
             -f description="Skipped for version-only PR (code validated on main)"
+
+  canary:
+    name: Canary Release
+    if: >-
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'canary')
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency:
+      group: canary-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+
+      - name: Set canary version
+        id: version
+        working-directory: packages/storybook-addon-performance-panel
+        run: |
+          base_version=$(node -p "require('./package.json').version")
+          short_sha=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          canary_version="${base_version}-canary.${short_sha}"
+          npm version "$canary_version" --no-git-tag-version
+          echo "version=$canary_version" >> "$GITHUB_OUTPUT"
+
+      - name: Publish canary
+        working-directory: packages/storybook-addon-performance-panel
+        run: npm publish --tag canary --provenance --access public
+        env:
+          NPM_TOKEN: ''
+          NPM_CONFIG_PROVENANCE: true
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        env:
+          CANARY_VERSION: ${{ steps.version.outputs.version }}
+        with:
+          script: |
+            const pkg = '@github-ui/storybook-addon-performance-panel';
+            const version = process.env.CANARY_VERSION;
+            const marker = '<!-- canary-release-comment -->';
+            const body = [
+              marker,
+              `### 📦 Canary Release`,
+              '',
+              '| Package | Version |',
+              '| --- | --- |',
+              `| \`${pkg}\` | [\`${version}\`](https://www.npmjs.com/package/${pkg}/v/${version}) |`,
+              '',
+              '```sh',
+              `npm install ${pkg}@${version}`,
+              '```',
+              '',
+              `_Published from ${context.sha.slice(0, 7)}_`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

Two infrastructure improvements to streamline development and testing workflows.

### 1. Devcontainer: Prebuild-optimized lifecycle hooks

**Before:** `postCreateCommand` ran `npm install` on every container start.

**After:** Split into prebuild-friendly hooks:

| Hook | Command | Purpose |
|------|---------|---------|
| `onCreateCommand` | `npm install && npx playwright install --with-deps` | Runs once during prebuild — installs deps + all Playwright browsers (chromium, firefox, webkit) with system dependencies |
| `updateContentCommand` | `npm install` | Re-runs if the lockfile changes between prebuild refreshes |

This enables Codespace prebuilds to cache the heavy `npm install` and Playwright browser installation, reducing new Codespace startup time significantly.

### 2. Canary releases from pull requests

Adds a `canary` job to the existing `publish.yml` workflow that publishes prerelease versions from PRs:

- **Trigger:** PRs with the `canary` label (requires repo write access to add)
- **Version format:** `x.y.z-canary.<short-sha>` (e.g., `1.0.1-canary.abc1234`)
- **npm tag:** `canary` (does not affect `latest`)
- **Auth:** OIDC provenance via the existing `production` environment — no additional tokens or npm configuration needed
- **PR comment:** Persistent (find/update) comment with the published version and install command

**Security model:**
- Label gating prevents arbitrary PRs from publishing
- Labels require repo write access — external contributors cannot trigger canary publishes
- `production` environment protection rules apply (required reviewers if configured)
- Release job uses `cancel-in-progress: false` to prevent interrupted production publishes

**Concurrency:**
- Release job: `cancel-in-progress: false` — production publishes run to completion
- Canary job: `cancel-in-progress: true` per PR number — superseded pushes cancel stale canary builds

### npm configuration required

The existing trusted publishing entry (`publish.yml` / `production`) covers both jobs since they share the same workflow filename and environment. No additional npm configuration needed.