### PR TITLE
Scope buffered performance metrics to each story

### DIFF
--- a/.changeset/story-scoped-metrics.md
+++ b/.changeset/story-scoped-metrics.md
@@ -1,0 +1,5 @@
+---
+'@github-ui/storybook-addon-performance-panel': minor
+---
+
+Scope buffered browser performance entries to the active story and report Element Timing values relative to story start.

--- a/packages/storybook-addon-performance-panel/__tests__/performance-decorator.browser.test.tsx
+++ b/packages/storybook-addon-performance-panel/__tests__/performance-decorator.browser.test.tsx
@@ -4,6 +4,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {render} from 'vitest-browser-react'
 
 import {PERF_EVENTS} from '../core/performance-types'
+import {PerformanceMonitorCore} from '../core/preview-core'
 import {PerformanceProvider, ProfiledComponent, withPerformanceMonitor} from '../react/performance-decorator'
 import {useReportReactRenderProfile} from '../react/ReportReactRenderProfileContext'
 
@@ -19,6 +20,25 @@ vi.mock('storybook/preview-api', () => ({
     getChannel: () => mockChannel,
   },
 }))
+
+class TestErrorBoundary extends React.Component<
+  {children: React.ReactNode; onError: (error: Error) => void},
+  {hasError: boolean}
+> {
+  override state = {hasError: false}
+
+  static getDerivedStateFromError() {
+    return {hasError: true}
+  }
+
+  override componentDidCatch(error: Error) {
+    this.props.onError(error)
+  }
+
+  override render() {
+    return this.state.hasError ? null : this.props.children
+  }
+}
 
 describe('performance-decorator', () => {
   beforeEach(() => {
@@ -65,6 +85,36 @@ describe('performance-decorator', () => {
       )
 
       expect(mockChannel.on).not.toHaveBeenCalled()
+    })
+
+    it('resets metrics only when the story ID changes', async () => {
+      const resetSpy = vi.spyOn(PerformanceMonitorCore.prototype, 'reset')
+
+      function StorySwitcher() {
+        const [storyId, setStoryId] = React.useState('story-a')
+        return (
+          <>
+            <button
+              data-testid="switch-story"
+              onClick={() => {
+                setStoryId('story-b')
+              }}
+            >
+              Switch story
+            </button>
+            <PerformanceProvider storyId={storyId}>
+              <div>Test</div>
+            </PerformanceProvider>
+          </>
+        )
+      }
+
+      await render(<StorySwitcher />)
+      expect(resetSpy).not.toHaveBeenCalled()
+
+      await userEvent.click(page.getByTestId('switch-story'))
+      await expect.poll(() => resetSpy.mock.calls.length).toBe(1)
+      resetSpy.mockRestore()
     })
 
     it('emits metrics periodically', async () => {
@@ -144,19 +194,26 @@ describe('performance-decorator', () => {
   })
 
   describe('useReportReactRenderProfile', () => {
-    it('throws outside of PerformanceProvider', () => {
+    it('throws outside of PerformanceProvider', async () => {
       // Suppress React's console.error for expected error boundary behavior
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const onError = vi.fn()
 
       function TestComponent() {
         useReportReactRenderProfile()
         return null
       }
 
-      expect(() => render(<TestComponent />)).toThrow(
-        'useReportReactRenderProfile must be used within a PerformanceProvider',
+      await render(
+        <TestErrorBoundary onError={onError}>
+          <TestComponent />
+        </TestErrorBoundary>,
       )
+      await expect.poll(() => onError.mock.calls.length).toBe(1)
+      expect(onError.mock.calls[0]?.[0]).toMatchObject({
+        message: 'useReportReactRenderProfile must be used within a PerformanceProvider',
+      })
 
       consoleSpy.mockRestore()
     })
@@ -186,22 +243,24 @@ describe('performance-decorator', () => {
       // Suppress React's console.error for expected error boundary behavior
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const onError = vi.fn()
 
       function TestComponent() {
         useReportReactRenderProfile()
         return null
       }
 
-      await expect
-        .poll(
-          async () =>
-            await render(
-              <PerformanceProvider storyId="test-story" enabled={false}>
-                <TestComponent />
-              </PerformanceProvider>,
-            ),
-        )
-        .toThrow('useReportReactRenderProfile must be used within a PerformanceProvider')
+      await render(
+        <TestErrorBoundary onError={onError}>
+          <PerformanceProvider storyId="test-story" enabled={false}>
+            <TestComponent />
+          </PerformanceProvider>
+        </TestErrorBoundary>,
+      )
+      await expect.poll(() => onError.mock.calls.length).toBe(1)
+      expect(onError.mock.calls[0]?.[0]).toMatchObject({
+        message: 'useReportReactRenderProfile must be used within a PerformanceProvider',
+      })
 
       consoleSpy.mockRestore()
     })
@@ -260,7 +319,7 @@ describe('performance-decorator', () => {
   describe('withPerformanceMonitor', () => {
     it('wraps story in PerformanceProvider and ProfiledComponent', async () => {
       const Story = () => <div data-testid="story">Story Content</div>
-      const context = {id: 'test-story'} as Parameters<typeof withPerformanceMonitor>[1]
+      const context = {id: 'test-story', parameters: {}} as Parameters<typeof withPerformanceMonitor>[1]
 
       const WrappedStory = () => withPerformanceMonitor(Story, context)
 
@@ -272,7 +331,7 @@ describe('performance-decorator', () => {
 
     it('emits metrics for wrapped story', async () => {
       const Story = () => <div>Story</div>
-      const context = {id: 'test-story'} as Parameters<typeof withPerformanceMonitor>[1]
+      const context = {id: 'test-story', parameters: {}} as Parameters<typeof withPerformanceMonitor>[1]
 
       const WrappedStory = () => withPerformanceMonitor(Story, context)
 

--- a/packages/storybook-addon-performance-panel/collectors/__tests__/element-timing-collector.browser.test.ts
+++ b/packages/storybook-addon-performance-panel/collectors/__tests__/element-timing-collector.browser.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment browser
  */
 
-import {beforeEach, describe, expect, it} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {ElementTimingCollector} from '../../collectors/element-timing-collector'
 
@@ -11,6 +11,11 @@ describe('ElementTimingCollector', () => {
 
   beforeEach(() => {
     collector = new ElementTimingCollector()
+  })
+
+  afterEach(() => {
+    collector.stop()
+    vi.unstubAllGlobals()
   })
 
   it('initializes with empty metrics', () => {
@@ -77,5 +82,61 @@ describe('ElementTimingCollector', () => {
       }
     })()
     expect(metrics.elementTimingSupported).toBe(expected)
+  })
+
+  it('reports render time relative to the current story epoch', () => {
+    const observerCallbacks: PerformanceObserverCallback[] = []
+    vi.stubGlobal(
+      'PerformanceObserver',
+      class MockPerformanceObserver {
+        static supportedEntryTypes = ['element']
+        constructor(callback: PerformanceObserverCallback) {
+          observerCallbacks.push(callback)
+        }
+        observe() {
+          /* empty */
+        }
+        disconnect() {
+          /* empty */
+        }
+      },
+    )
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(1_000)
+    const scopedCollector = new ElementTimingCollector()
+    scopedCollector.start()
+
+    const entryList: PerformanceObserverEntryList = {
+      getEntries: () => [
+        {
+          renderTime: 1_125,
+          loadTime: 1_100,
+          identifier: 'hero',
+          element: null,
+          naturalWidth: 0,
+          naturalHeight: 0,
+          url: '',
+        } as unknown as PerformanceEntry,
+      ],
+      getEntriesByName: () => [],
+      getEntriesByType: () => [],
+    }
+    const observer: PerformanceObserver = {
+      disconnect() {
+        /* empty */
+      },
+      observe() {
+        /* empty */
+      },
+      takeRecords: () => [],
+    }
+
+    observerCallbacks[0]?.(entryList, observer)
+
+    expect(scopedCollector.getMetrics()).toMatchObject({
+      largestRenderTime: 125,
+      elements: [{identifier: 'hero', renderTime: 125, loadTime: 100}],
+    })
+    scopedCollector.stop()
+    nowSpy.mockRestore()
   })
 })

--- a/packages/storybook-addon-performance-panel/collectors/__tests__/input-collector.browser.test.ts
+++ b/packages/storybook-addon-performance-panel/collectors/__tests__/input-collector.browser.test.ts
@@ -96,6 +96,7 @@ describe('InputCollector', () => {
 
   it('counts only interactions observed during the current story', () => {
     const observerCallbacks: PerformanceObserverCallback[] = []
+    vi.spyOn(performance, 'interactionCount', 'get').mockImplementation(() => undefined as unknown as number)
     vi.stubGlobal(
       'PerformanceObserver',
       class MockPerformanceObserver {
@@ -159,6 +160,49 @@ describe('InputCollector', () => {
     scopedCollector.stop()
   })
 
+  it('prefers the native count over user-agent-specific interaction ID spacing', () => {
+    const observerCallbacks: PerformanceObserverCallback[] = []
+    vi.stubGlobal(
+      'PerformanceObserver',
+      class MockPerformanceObserver {
+        static supportedEntryTypes = ['event', 'first-input']
+        constructor(callback: PerformanceObserverCallback) {
+          observerCallbacks.push(callback)
+        }
+        observe() {
+          /* empty */
+        }
+        disconnect() {
+          /* empty */
+        }
+      },
+    )
+    let nativeInteractionCount = 12
+    vi.spyOn(performance, 'interactionCount', 'get').mockImplementation(() => nativeInteractionCount)
+
+    const scopedCollector = new InputCollector()
+    scopedCollector.start()
+    const startTime = performance.now()
+    observerCallbacks[0]?.(
+      {
+        getEntries: () =>
+          [1, 11].map(interactionId => ({
+            startTime,
+            duration: 40,
+            processingStart: startTime + 5,
+            processingEnd: startTime + 10,
+            interactionId,
+            name: 'click',
+          })),
+      } as unknown as PerformanceObserverEntryList,
+      {} as PerformanceObserver,
+    )
+    nativeInteractionCount = 14
+
+    expect(scopedCollector.getMetrics().interactionCount).toBe(2)
+    scopedCollector.stop()
+  })
+
   it('does not include native interactions while collection is stopped', () => {
     let nativeInteractionCount = 20
     vi.spyOn(performance, 'interactionCount', 'get').mockImplementation(() => nativeInteractionCount)
@@ -178,6 +222,7 @@ describe('InputCollector', () => {
 
   it('does not recount interactions removed from the bounded latency sample', () => {
     const observerCallbacks: PerformanceObserverCallback[] = []
+    vi.spyOn(performance, 'interactionCount', 'get').mockImplementation(() => undefined as unknown as number)
     vi.stubGlobal(
       'PerformanceObserver',
       class MockPerformanceObserver {

--- a/packages/storybook-addon-performance-panel/collectors/__tests__/input-collector.browser.test.ts
+++ b/packages/storybook-addon-performance-panel/collectors/__tests__/input-collector.browser.test.ts
@@ -143,6 +143,53 @@ describe('InputCollector', () => {
     scopedCollector.stop()
   })
 
+  it('does not recount interactions removed from the bounded latency sample', () => {
+    const observerCallbacks: PerformanceObserverCallback[] = []
+    vi.stubGlobal(
+      'PerformanceObserver',
+      class MockPerformanceObserver {
+        static supportedEntryTypes = ['event', 'first-input']
+        constructor(callback: PerformanceObserverCallback) {
+          observerCallbacks.push(callback)
+        }
+        observe() {
+          /* empty */
+        }
+        disconnect() {
+          /* empty */
+        }
+      },
+    )
+
+    const scopedCollector = new InputCollector()
+    scopedCollector.start()
+    const startTime = performance.now()
+    const makeEntry = (interactionId: number, duration: number) => ({
+      startTime,
+      duration,
+      processingStart: startTime + 1,
+      processingEnd: startTime + 2,
+      interactionId,
+      name: 'click',
+    })
+    const entryList = (entries: ReturnType<typeof makeEntry>[]) =>
+      ({getEntries: () => entries}) as unknown as PerformanceObserverEntryList
+
+    observerCallbacks[0]?.(
+      entryList(Array.from({length: 501}, (_, index) => makeEntry(index + 1, 501 - index))),
+      {} as PerformanceObserver,
+    )
+    expect(scopedCollector.getMetrics().interactionCount).toBe(501)
+
+    observerCallbacks[0]?.(entryList([makeEntry(501, 1)]), {} as PerformanceObserver)
+    expect(scopedCollector.getMetrics().interactionCount).toBe(501)
+
+    scopedCollector.reset()
+    observerCallbacks[0]?.(entryList([makeEntry(501, 1)]), {} as PerformanceObserver)
+    expect(scopedCollector.getMetrics().interactionCount).toBe(1)
+    scopedCollector.stop()
+  })
+
   // Note: Interaction tracking is now handled via PerformanceObserver with 'event' entry type
   // (Event Timing API) when supported, which provides more accurate INP measurements.
   // The old manual click/keydown listeners have been removed in favor of the browser's

--- a/packages/storybook-addon-performance-panel/collectors/__tests__/input-collector.browser.test.ts
+++ b/packages/storybook-addon-performance-panel/collectors/__tests__/input-collector.browser.test.ts
@@ -143,6 +143,39 @@ describe('InputCollector', () => {
     scopedCollector.stop()
   })
 
+  it('reports the story-local delta from the native interaction count', () => {
+    let nativeInteractionCount = 12
+    vi.spyOn(performance, 'interactionCount', 'get').mockImplementation(() => nativeInteractionCount)
+
+    const scopedCollector = new InputCollector()
+    scopedCollector.start()
+    nativeInteractionCount = 15
+
+    expect(scopedCollector.getMetrics().interactionCount).toBe(3)
+
+    scopedCollector.reset()
+    nativeInteractionCount = 16
+    expect(scopedCollector.getMetrics().interactionCount).toBe(1)
+    scopedCollector.stop()
+  })
+
+  it('does not include native interactions while collection is stopped', () => {
+    let nativeInteractionCount = 20
+    vi.spyOn(performance, 'interactionCount', 'get').mockImplementation(() => nativeInteractionCount)
+
+    const scopedCollector = new InputCollector()
+    scopedCollector.start()
+    nativeInteractionCount = 22
+    scopedCollector.stop()
+
+    nativeInteractionCount = 30
+    scopedCollector.start()
+    nativeInteractionCount = 31
+
+    expect(scopedCollector.getMetrics().interactionCount).toBe(3)
+    scopedCollector.stop()
+  })
+
   it('does not recount interactions removed from the bounded latency sample', () => {
     const observerCallbacks: PerformanceObserverCallback[] = []
     vi.stubGlobal(
@@ -164,6 +197,7 @@ describe('InputCollector', () => {
     const scopedCollector = new InputCollector()
     scopedCollector.start()
     const startTime = performance.now()
+    const lastInteractionId = 1 + 500 * 7
     const makeEntry = (interactionId: number, duration: number) => ({
       startTime,
       duration,
@@ -176,16 +210,16 @@ describe('InputCollector', () => {
       ({getEntries: () => entries}) as unknown as PerformanceObserverEntryList
 
     observerCallbacks[0]?.(
-      entryList(Array.from({length: 501}, (_, index) => makeEntry(index + 1, 501 - index))),
+      entryList(Array.from({length: 501}, (_, index) => makeEntry(1 + index * 7, 501 - index))),
       {} as PerformanceObserver,
     )
     expect(scopedCollector.getMetrics().interactionCount).toBe(501)
 
-    observerCallbacks[0]?.(entryList([makeEntry(501, 1)]), {} as PerformanceObserver)
+    observerCallbacks[0]?.(entryList([makeEntry(lastInteractionId, 1)]), {} as PerformanceObserver)
     expect(scopedCollector.getMetrics().interactionCount).toBe(501)
 
     scopedCollector.reset()
-    observerCallbacks[0]?.(entryList([makeEntry(501, 1)]), {} as PerformanceObserver)
+    observerCallbacks[0]?.(entryList([makeEntry(lastInteractionId, 1)]), {} as PerformanceObserver)
     expect(scopedCollector.getMetrics().interactionCount).toBe(1)
     scopedCollector.stop()
   })

--- a/packages/storybook-addon-performance-panel/collectors/__tests__/input-collector.browser.test.ts
+++ b/packages/storybook-addon-performance-panel/collectors/__tests__/input-collector.browser.test.ts
@@ -12,6 +12,7 @@ describe('InputCollector', () => {
 
   afterEach(() => {
     collector.stop()
+    vi.unstubAllGlobals()
     vi.useRealTimers()
   })
 
@@ -91,6 +92,55 @@ describe('InputCollector', () => {
       // Interaction type breakdown
       expect(metrics.interactionsByType).toEqual({})
     })
+  })
+
+  it('counts only interactions observed during the current story', () => {
+    const observerCallbacks: PerformanceObserverCallback[] = []
+    vi.stubGlobal(
+      'PerformanceObserver',
+      class MockPerformanceObserver {
+        static supportedEntryTypes = ['event', 'first-input']
+        constructor(callback: PerformanceObserverCallback) {
+          observerCallbacks.push(callback)
+        }
+        observe() {
+          /* empty */
+        }
+        disconnect() {
+          /* empty */
+        }
+      },
+    )
+
+    const scopedCollector = new InputCollector()
+    const staleStartTime = performance.now() - 1
+    scopedCollector.start()
+    observerCallbacks[0]?.(
+      {
+        getEntries: () => [
+          {
+            startTime: staleStartTime,
+            duration: 90,
+            processingStart: staleStartTime + 10,
+            processingEnd: staleStartTime + 20,
+            interactionId: 1,
+            name: 'click',
+          },
+          {
+            startTime: performance.now(),
+            duration: 40,
+            processingStart: performance.now() + 5,
+            processingEnd: performance.now() + 10,
+            interactionId: 2,
+            name: 'click',
+          },
+        ],
+      } as unknown as PerformanceObserverEntryList,
+      {} as PerformanceObserver,
+    )
+
+    expect(scopedCollector.getMetrics()).toMatchObject({interactionCount: 1, inpMs: 40})
+    scopedCollector.stop()
   })
 
   // Note: Interaction tracking is now handled via PerformanceObserver with 'event' entry type

--- a/packages/storybook-addon-performance-panel/collectors/__tests__/layout-shift-collector.browser.test.ts
+++ b/packages/storybook-addon-performance-panel/collectors/__tests__/layout-shift-collector.browser.test.ts
@@ -1,0 +1,67 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {LayoutShiftCollector} from '../layout-shift-collector'
+
+describe('LayoutShiftCollector', () => {
+  let collector: LayoutShiftCollector
+  let observerCallback: PerformanceObserverCallback | null = null
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'PerformanceObserver',
+      class MockPerformanceObserver {
+        constructor(callback: PerformanceObserverCallback) {
+          observerCallback = callback
+        }
+        observe() {
+          /* empty */
+        }
+        disconnect() {
+          /* empty */
+        }
+      },
+    )
+    collector = new LayoutShiftCollector()
+  })
+
+  afterEach(() => {
+    collector.stop()
+    vi.unstubAllGlobals()
+    observerCallback = null
+  })
+
+  it('ignores buffered shifts from before the collector started', () => {
+    const staleStartTime = performance.now() - 1
+    collector.start()
+
+    observerCallback?.(
+      {
+        getEntries: () => [
+          {startTime: staleStartTime, value: 0.2, hadRecentInput: false},
+          {startTime: performance.now(), value: 0.05, hadRecentInput: false},
+        ],
+      } as unknown as PerformanceObserverEntryList,
+      {} as PerformanceObserver,
+    )
+
+    expect(collector.getMetrics()).toMatchObject({layoutShiftCount: 1, layoutShiftScore: 0.05})
+  })
+
+  it('moves the epoch forward when metrics are reset', () => {
+    collector.start()
+    const oldStartTime = performance.now() - 1
+    collector.reset()
+
+    observerCallback?.(
+      {
+        getEntries: () => [{startTime: oldStartTime, value: 0.2, hadRecentInput: false}],
+      } as unknown as PerformanceObserverEntryList,
+      {} as PerformanceObserver,
+    )
+
+    expect(collector.getMetrics()).toMatchObject({
+      layoutShiftCount: 0,
+      layoutShiftScore: 0,
+    })
+  })
+})

--- a/packages/storybook-addon-performance-panel/collectors/__tests__/long-animation-frame-collector.browser.test.ts
+++ b/packages/storybook-addon-performance-panel/collectors/__tests__/long-animation-frame-collector.browser.test.ts
@@ -1,16 +1,34 @@
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {LongAnimationFrameCollector} from '../../collectors/long-animation-frame-collector'
 
 describe('LongAnimationFrameCollector', () => {
   let collector: LongAnimationFrameCollector
+  let observerCallback: PerformanceObserverCallback | null = null
 
   beforeEach(() => {
+    vi.stubGlobal(
+      'PerformanceObserver',
+      class MockPerformanceObserver {
+        static supportedEntryTypes = ['long-animation-frame']
+        constructor(callback: PerformanceObserverCallback) {
+          observerCallback = callback
+        }
+        observe() {
+          /* empty */
+        }
+        disconnect() {
+          /* empty */
+        }
+      },
+    )
     collector = new LongAnimationFrameCollector()
   })
 
   afterEach(() => {
     collector.stop()
+    vi.unstubAllGlobals()
+    observerCallback = null
   })
 
   describe('getMetrics', () => {
@@ -49,6 +67,23 @@ describe('LongAnimationFrameCollector', () => {
       expect(metrics.lastLoaf).toBeNull()
       expect(metrics.worstLoaf).toBeNull()
     })
+  })
+
+  it('ignores buffered frames from before the collector started', () => {
+    const staleStartTime = performance.now() - 1
+    collector.start()
+
+    observerCallback?.(
+      {
+        getEntries: () => [
+          {startTime: staleStartTime, duration: 100, blockingDuration: 50},
+          {startTime: performance.now(), duration: 80, blockingDuration: 30},
+        ],
+      } as unknown as PerformanceObserverEntryList,
+      {} as PerformanceObserver,
+    )
+
+    expect(collector.getMetrics()).toMatchObject({loafCount: 1, longestLoafDuration: 80})
   })
 
   describe('start/stop', () => {

--- a/packages/storybook-addon-performance-panel/collectors/__tests__/paint-collector.browser.test.ts
+++ b/packages/storybook-addon-performance-panel/collectors/__tests__/paint-collector.browser.test.ts
@@ -87,12 +87,13 @@ describe('PaintCollector', () => {
 
     it('counts paint events', () => {
       collector.start()
+      const startTime = performance.now()
 
       paintObserverCallback?.(
         {
           getEntries: () => [
-            {entryType: 'paint', name: 'first-paint'},
-            {entryType: 'paint', name: 'first-contentful-paint'},
+            {entryType: 'paint', name: 'first-paint', startTime},
+            {entryType: 'paint', name: 'first-contentful-paint', startTime},
           ],
         } as unknown as PerformanceObserverEntryList,
         {} as PerformanceObserver,
@@ -104,17 +105,21 @@ describe('PaintCollector', () => {
 
     it('accumulates paint count', () => {
       collector.start()
+      const startTime = performance.now()
 
       paintObserverCallback?.(
         {
-          getEntries: () => [{entryType: 'paint'}],
+          getEntries: () => [{entryType: 'paint', startTime}],
         } as unknown as PerformanceObserverEntryList,
         {} as PerformanceObserver,
       )
 
       paintObserverCallback?.(
         {
-          getEntries: () => [{entryType: 'paint'}, {entryType: 'paint'}],
+          getEntries: () => [
+            {entryType: 'paint', startTime},
+            {entryType: 'paint', startTime},
+          ],
         } as unknown as PerformanceObserverEntryList,
         {} as PerformanceObserver,
       )
@@ -125,12 +130,14 @@ describe('PaintCollector', () => {
 
     it('tracks script evaluation time', () => {
       collector.start()
+      const startTime = performance.now()
 
       resourceObserverCallback?.(
         {
           getEntries: () => [
             {
               entryType: 'resource',
+              startTime,
               initiatorType: 'script',
               fetchStart: 100,
               responseEnd: 150,
@@ -146,12 +153,13 @@ describe('PaintCollector', () => {
 
     it('accumulates script time from multiple scripts', () => {
       collector.start()
+      const startTime = performance.now()
 
       resourceObserverCallback?.(
         {
           getEntries: () => [
-            {entryType: 'resource', initiatorType: 'script', fetchStart: 100, responseEnd: 130},
-            {entryType: 'resource', initiatorType: 'script', fetchStart: 200, responseEnd: 250},
+            {entryType: 'resource', initiatorType: 'script', startTime, fetchStart: 100, responseEnd: 130},
+            {entryType: 'resource', initiatorType: 'script', startTime, fetchStart: 200, responseEnd: 250},
           ],
         } as unknown as PerformanceObserverEntryList,
         {} as PerformanceObserver,
@@ -163,12 +171,13 @@ describe('PaintCollector', () => {
 
     it('ignores non-script resources', () => {
       collector.start()
+      const startTime = performance.now()
 
       resourceObserverCallback?.(
         {
           getEntries: () => [
-            {entryType: 'resource', initiatorType: 'img', fetchStart: 100, responseEnd: 200},
-            {entryType: 'resource', initiatorType: 'css', fetchStart: 100, responseEnd: 200},
+            {entryType: 'resource', initiatorType: 'img', startTime, fetchStart: 100, responseEnd: 200},
+            {entryType: 'resource', initiatorType: 'css', startTime, fetchStart: 100, responseEnd: 200},
           ],
         } as unknown as PerformanceObserverEntryList,
         {} as PerformanceObserver,
@@ -176,6 +185,34 @@ describe('PaintCollector', () => {
 
       const metrics = collector.getMetrics()
       expect(metrics.scriptEvalTime).toBe(0)
+    })
+
+    it('ignores buffered entries from before the collector started', () => {
+      const staleStartTime = performance.now() - 1
+      collector.start()
+
+      paintObserverCallback?.(
+        {
+          getEntries: () => [{entryType: 'paint', startTime: staleStartTime}],
+        } as unknown as PerformanceObserverEntryList,
+        {} as PerformanceObserver,
+      )
+      resourceObserverCallback?.(
+        {
+          getEntries: () => [
+            {
+              entryType: 'resource',
+              initiatorType: 'script',
+              startTime: staleStartTime,
+              fetchStart: 100,
+              responseEnd: 150,
+            },
+          ],
+        } as unknown as PerformanceObserverEntryList,
+        {} as PerformanceObserver,
+      )
+
+      expect(collector.getMetrics()).toMatchObject({paintCount: 0, scriptEvalTime: 0})
     })
   })
 

--- a/packages/storybook-addon-performance-panel/collectors/element-timing-collector.ts
+++ b/packages/storybook-addon-performance-panel/collectors/element-timing-collector.ts
@@ -144,15 +144,17 @@ export class ElementTimingCollector implements MetricCollector<ElementTimingMetr
 
   #processEntry(entry: PerformanceElementTiming): void {
     // Use renderTime if available, fall back to loadTime for images
-    const renderTime = entry.renderTime || entry.loadTime || 0
+    const entryTime = entry.renderTime || entry.loadTime || 0
 
     // Ignore entries from before the current epoch (stale after reset/restart)
-    if (renderTime < this.#epochMs) return
+    if (entryTime < this.#epochMs) return
+
+    const renderTime = entryTime - this.#epochMs
 
     const record: ElementTimingRecord = {
       identifier: entry.identifier || 'unnamed',
       renderTime,
-      loadTime: entry.loadTime || 0,
+      loadTime: entry.loadTime > 0 ? Math.max(0, entry.loadTime - this.#epochMs) : 0,
       selector: getSimpleSelector(entry.element),
       tagName: entry.element?.tagName.toLowerCase() ?? 'unknown',
     }

--- a/packages/storybook-addon-performance-panel/collectors/input-collector.ts
+++ b/packages/storybook-addon-performance-panel/collectors/input-collector.ts
@@ -128,7 +128,7 @@ export class InputCollector implements MetricCollector<InputMetrics> {
 
   /** Cap to prevent unbounded growth during long sessions */
   static readonly #MAX_INTERACTIONS = 500
-  /** Browsers increment interaction IDs by seven to reduce fingerprinting precision. */
+  /** Legacy Chromium uses a step of seven when the native interaction count is unavailable. */
   static readonly #INTERACTION_ID_INCREMENT = 7
 
   // First Input Delay tracking
@@ -251,10 +251,12 @@ export class InputCollector implements MetricCollector<InputMetrics> {
     // Track the worst duration for each interaction
     // (an interaction may have multiple events, e.g., keydown + keyup)
     const existingDuration = this.#interactionMap.get(interactionId)
-    this.#minKnownInteractionId = Math.min(this.#minKnownInteractionId, interactionId)
-    this.#maxKnownInteractionId = Math.max(this.#maxKnownInteractionId, interactionId)
-    this.#interactionCountEstimate =
-      (this.#maxKnownInteractionId - this.#minKnownInteractionId) / InputCollector.#INTERACTION_ID_INCREMENT + 1
+    if (this.#nativeInteractionCountBaseline === null) {
+      this.#minKnownInteractionId = Math.min(this.#minKnownInteractionId, interactionId)
+      this.#maxKnownInteractionId = Math.max(this.#maxKnownInteractionId, interactionId)
+      this.#interactionCountEstimate =
+        (this.#maxKnownInteractionId - this.#minKnownInteractionId) / InputCollector.#INTERACTION_ID_INCREMENT + 1
+    }
     if (duration > (existingDuration ?? 0)) {
       this.#interactionMap.set(interactionId, duration)
 
@@ -377,12 +379,13 @@ export class InputCollector implements MetricCollector<InputMetrics> {
 
   #getInteractionCount(): number {
     const currentNativeCount = this.#readNativeInteractionCount()
-    const currentNativeDelta =
-      currentNativeCount !== null && this.#nativeInteractionCountBaseline !== null
-        ? Math.max(0, currentNativeCount - this.#nativeInteractionCountBaseline)
-        : 0
+    if (currentNativeCount === null) return this.#interactionCountEstimate
 
-    return Math.max(this.#nativeInteractionCountOffset + currentNativeDelta, this.#interactionCountEstimate)
+    const currentNativeDelta =
+      this.#nativeInteractionCountBaseline === null
+        ? 0
+        : Math.max(0, currentNativeCount - this.#nativeInteractionCountBaseline)
+    return this.#nativeInteractionCountOffset + currentNativeDelta
   }
 
   #commitNativeInteractionCount(): void {

--- a/packages/storybook-addon-performance-panel/collectors/input-collector.ts
+++ b/packages/storybook-addon-performance-panel/collectors/input-collector.ts
@@ -110,7 +110,7 @@ export class InputCollector implements MetricCollector<InputMetrics> {
   #maxPaintTime = 0
   #paintJitter = 0
   #recentPaintTimes: number[] = []
-  #interactionCount = 0
+  #interactionCountEstimate = 0
   #interactionLatencies: number[] = []
   #inpMs = 0
 
@@ -121,10 +121,15 @@ export class InputCollector implements MetricCollector<InputMetrics> {
 
   // Track worst latency per interaction (interactionId -> max duration)
   #interactionMap = new Map<number, number>()
-  #seenInteractionIds = new Set<number>()
+  #minKnownInteractionId = Infinity
+  #maxKnownInteractionId = 0
+  #nativeInteractionCountOffset = 0
+  #nativeInteractionCountBaseline: number | null = null
 
   /** Cap to prevent unbounded growth during long sessions */
   static readonly #MAX_INTERACTIONS = 500
+  /** Browsers increment interaction IDs by seven to reduce fingerprinting precision. */
+  static readonly #INTERACTION_ID_INCREMENT = 7
 
   // First Input Delay tracking
   #firstInputDelay: number | null = null
@@ -165,6 +170,7 @@ export class InputCollector implements MetricCollector<InputMetrics> {
 
   start(): void {
     this.#epochMs = performance.now()
+    this.#nativeInteractionCountBaseline = this.#readNativeInteractionCount()
 
     // Always track pointermove for continuous input latency (hover responsiveness)
     window.addEventListener('pointermove', this.#boundHandlePointerMove)
@@ -245,10 +251,10 @@ export class InputCollector implements MetricCollector<InputMetrics> {
     // Track the worst duration for each interaction
     // (an interaction may have multiple events, e.g., keydown + keyup)
     const existingDuration = this.#interactionMap.get(interactionId)
-    if (!this.#seenInteractionIds.has(interactionId)) {
-      this.#seenInteractionIds.add(interactionId)
-      this.#interactionCount++
-    }
+    this.#minKnownInteractionId = Math.min(this.#minKnownInteractionId, interactionId)
+    this.#maxKnownInteractionId = Math.max(this.#maxKnownInteractionId, interactionId)
+    this.#interactionCountEstimate =
+      (this.#maxKnownInteractionId - this.#minKnownInteractionId) / InputCollector.#INTERACTION_ID_INCREMENT + 1
     if (duration > (existingDuration ?? 0)) {
       this.#interactionMap.set(interactionId, duration)
 
@@ -305,6 +311,7 @@ export class InputCollector implements MetricCollector<InputMetrics> {
   }
 
   stop(): void {
+    this.#commitNativeInteractionCount()
     window.removeEventListener('pointermove', this.#boundHandlePointerMove)
     this.#eventTimingObserver?.disconnect()
     this.#firstInputObserver?.disconnect()
@@ -321,14 +328,17 @@ export class InputCollector implements MetricCollector<InputMetrics> {
     this.#maxPaintTime = 0
     this.#paintJitter = 0
     this.#recentPaintTimes = []
-    this.#interactionCount = 0
+    this.#interactionCountEstimate = 0
     this.#interactionLatencies = []
     this.#inpMs = 0
     this.#inputDelays = []
     this.#processingTimes = []
     this.#presentationDelays = []
     this.#interactionMap.clear()
-    this.#seenInteractionIds.clear()
+    this.#minKnownInteractionId = Infinity
+    this.#maxKnownInteractionId = 0
+    this.#nativeInteractionCountOffset = 0
+    this.#nativeInteractionCountBaseline = this.#readNativeInteractionCount()
     this.#firstInputDelay = null
     this.#firstInputType = null
     this.#slowestInteraction = null
@@ -346,7 +356,7 @@ export class InputCollector implements MetricCollector<InputMetrics> {
       maxPaintTime: this.#maxPaintTime,
       paintJitter: this.#paintJitter,
       eventTimingSupported: this.#eventTimingSupported,
-      interactionCount: this.#interactionCount,
+      interactionCount: this.#getInteractionCount(),
       interactionLatencies: this.#interactionLatencies,
       inpMs: this.#inpMs,
       avgInputDelay: computeAverage(this.#inputDelays),
@@ -358,6 +368,29 @@ export class InputCollector implements MetricCollector<InputMetrics> {
       lastInteraction: this.#lastInteraction,
       interactionsByType: {...this.#interactionsByType},
     }
+  }
+
+  #readNativeInteractionCount(): number | null {
+    const count = (performance as Performance & {interactionCount?: number}).interactionCount
+    return typeof count === 'number' ? count : null
+  }
+
+  #getInteractionCount(): number {
+    const currentNativeCount = this.#readNativeInteractionCount()
+    const currentNativeDelta =
+      currentNativeCount !== null && this.#nativeInteractionCountBaseline !== null
+        ? Math.max(0, currentNativeCount - this.#nativeInteractionCountBaseline)
+        : 0
+
+    return Math.max(this.#nativeInteractionCountOffset + currentNativeDelta, this.#interactionCountEstimate)
+  }
+
+  #commitNativeInteractionCount(): void {
+    const currentNativeCount = this.#readNativeInteractionCount()
+    if (currentNativeCount !== null && this.#nativeInteractionCountBaseline !== null) {
+      this.#nativeInteractionCountOffset += Math.max(0, currentNativeCount - this.#nativeInteractionCountBaseline)
+    }
+    this.#nativeInteractionCountBaseline = null
   }
 
   /**

--- a/packages/storybook-addon-performance-panel/collectors/input-collector.ts
+++ b/packages/storybook-addon-performance-panel/collectors/input-collector.ts
@@ -121,6 +121,7 @@ export class InputCollector implements MetricCollector<InputMetrics> {
 
   // Track worst latency per interaction (interactionId -> max duration)
   #interactionMap = new Map<number, number>()
+  #seenInteractionIds = new Set<number>()
 
   /** Cap to prevent unbounded growth during long sessions */
   static readonly #MAX_INTERACTIONS = 500
@@ -244,7 +245,8 @@ export class InputCollector implements MetricCollector<InputMetrics> {
     // Track the worst duration for each interaction
     // (an interaction may have multiple events, e.g., keydown + keyup)
     const existingDuration = this.#interactionMap.get(interactionId)
-    if (existingDuration === undefined) {
+    if (!this.#seenInteractionIds.has(interactionId)) {
+      this.#seenInteractionIds.add(interactionId)
       this.#interactionCount++
     }
     if (duration > (existingDuration ?? 0)) {
@@ -326,6 +328,7 @@ export class InputCollector implements MetricCollector<InputMetrics> {
     this.#processingTimes = []
     this.#presentationDelays = []
     this.#interactionMap.clear()
+    this.#seenInteractionIds.clear()
     this.#firstInputDelay = null
     this.#firstInputType = null
     this.#slowestInteraction = null

--- a/packages/storybook-addon-performance-panel/collectors/input-collector.ts
+++ b/packages/storybook-addon-performance-panel/collectors/input-collector.ts
@@ -141,6 +141,8 @@ export class InputCollector implements MetricCollector<InputMetrics> {
   #eventTimingObserver: PerformanceObserver | null = null
   #firstInputObserver: PerformanceObserver | null = null
   #eventTimingSupported = false
+  /** Entries before this timestamp belong to an earlier story or reset. */
+  #epochMs = 0
 
   #boundHandlePointerMove: (e: PointerEvent) => void
 
@@ -161,6 +163,8 @@ export class InputCollector implements MetricCollector<InputMetrics> {
   }
 
   start(): void {
+    this.#epochMs = performance.now()
+
     // Always track pointermove for continuous input latency (hover responsiveness)
     window.addEventListener('pointermove', this.#boundHandlePointerMove)
 
@@ -191,10 +195,11 @@ export class InputCollector implements MetricCollector<InputMetrics> {
       // This is guaranteed to report even for fast interactions
       this.#firstInputObserver = new PerformanceObserver(list => {
         const entries = list.getEntries()
-        if (entries.length > 0 && this.#firstInputDelay === null) {
-          const entry = entries[0] as PerformanceEventTiming
-          this.#firstInputDelay = entry.processingStart - entry.startTime
-          this.#firstInputType = entry.name
+        const entry = entries.find(candidate => candidate.startTime >= this.#epochMs)
+        if (entry && this.#firstInputDelay === null) {
+          const firstInput = entry as PerformanceEventTiming
+          this.#firstInputDelay = firstInput.processingStart - firstInput.startTime
+          this.#firstInputType = firstInput.name
         }
       })
       this.#firstInputObserver.observe({type: 'first-input', buffered: true})
@@ -205,6 +210,8 @@ export class InputCollector implements MetricCollector<InputMetrics> {
   }
 
   #processEventTimingEntry(entry: PerformanceEventTiming): void {
+    if (entry.startTime < this.#epochMs) return
+
     // Only count discrete interactions (click, keydown, etc.)
     // interactionId === 0 means it's not a discrete interaction
     if (entry.interactionId === 0) return
@@ -236,8 +243,11 @@ export class InputCollector implements MetricCollector<InputMetrics> {
 
     // Track the worst duration for each interaction
     // (an interaction may have multiple events, e.g., keydown + keyup)
-    const existingDuration = this.#interactionMap.get(interactionId) ?? 0
-    if (duration > existingDuration) {
+    const existingDuration = this.#interactionMap.get(interactionId)
+    if (existingDuration === undefined) {
+      this.#interactionCount++
+    }
+    if (duration > (existingDuration ?? 0)) {
       this.#interactionMap.set(interactionId, duration)
 
       // Update slowest interaction info if this is the new worst
@@ -250,9 +260,6 @@ export class InputCollector implements MetricCollector<InputMetrics> {
     addToWindow(this.#processingTimes, processingTime, INTERACTION_LATENCIES_WINDOW)
     addToWindow(this.#presentationDelays, presentationDelay, INTERACTION_LATENCIES_WINDOW)
 
-    // Update interaction tracking - prefer browser's count if available
-    const perfWithEventTiming = performance
-    this.#interactionCount = perfWithEventTiming.interactionCount
     addToWindow(this.#interactionLatencies, duration, INTERACTION_LATENCIES_WINDOW)
 
     // Prune map if it exceeds the cap to prevent unbounded growth
@@ -324,6 +331,7 @@ export class InputCollector implements MetricCollector<InputMetrics> {
     this.#slowestInteraction = null
     this.#lastInteraction = null
     this.#interactionsByType = {}
+    this.#epochMs = performance.now()
   }
 
   getMetrics(): InputMetrics {

--- a/packages/storybook-addon-performance-panel/collectors/layout-shift-collector.ts
+++ b/packages/storybook-addon-performance-panel/collectors/layout-shift-collector.ts
@@ -74,10 +74,13 @@ export class LayoutShiftCollector implements MetricCollector<LayoutMetrics> {
   #layoutShiftCount = 0
   /** Number of completed sessions */
   #sessionCount = 0
+  /** Entries before this timestamp belong to an earlier story or reset. */
+  #epochMs = 0
 
   #observer: PerformanceObserver | null = null
 
   start(): void {
+    this.#epochMs = performance.now()
     try {
       this.#observer = new PerformanceObserver(list => {
         for (const entry of list.getEntries()) {
@@ -91,6 +94,8 @@ export class LayoutShiftCollector implements MetricCollector<LayoutMetrics> {
   }
 
   #processEntry(entry: LayoutShift): void {
+    if (entry.startTime < this.#epochMs) return
+
     // Only count layout shifts without recent user input (per CLS spec)
     if (entry.hadRecentInput) return
 
@@ -144,6 +149,7 @@ export class LayoutShiftCollector implements MetricCollector<LayoutMetrics> {
     this.#sessionLastEntryTime = null
     this.#layoutShiftCount = 0
     this.#sessionCount = 0
+    this.#epochMs = performance.now()
   }
 
   getMetrics(): LayoutMetrics {

--- a/packages/storybook-addon-performance-panel/collectors/long-animation-frame-collector.ts
+++ b/packages/storybook-addon-performance-panel/collectors/long-animation-frame-collector.ts
@@ -122,6 +122,8 @@ export class LongAnimationFrameCollector implements MetricCollector<LongAnimatio
   #loafsWithScripts = 0
   #lastLoaf: LongAnimationFrameMetrics['lastLoaf'] = null
   #worstLoaf: LongAnimationFrameMetrics['worstLoaf'] = null
+  /** Entries before this timestamp belong to an earlier story or reset. */
+  #epochMs = 0
 
   #observer: PerformanceObserver | null = null
 
@@ -140,6 +142,7 @@ export class LongAnimationFrameCollector implements MetricCollector<LongAnimatio
   start(): void {
     if (!this.#loafSupported) return
 
+    this.#epochMs = performance.now()
     try {
       this.#observer = new PerformanceObserver(list => {
         for (const entry of list.getEntries()) {
@@ -153,6 +156,8 @@ export class LongAnimationFrameCollector implements MetricCollector<LongAnimatio
   }
 
   #processEntry(entry: PerformanceLongAnimationFrameTiming): void {
+    if (entry.startTime < this.#epochMs) return
+
     this.#loafCount++
     this.#totalBlockingDuration += entry.blockingDuration
 
@@ -218,6 +223,7 @@ export class LongAnimationFrameCollector implements MetricCollector<LongAnimatio
     this.#loafsWithScripts = 0
     this.#lastLoaf = null
     this.#worstLoaf = null
+    this.#epochMs = performance.now()
   }
 
   getMetrics(): LongAnimationFrameMetrics {

--- a/packages/storybook-addon-performance-panel/collectors/paint-collector.ts
+++ b/packages/storybook-addon-performance-panel/collectors/paint-collector.ts
@@ -57,12 +57,16 @@ export class PaintCollector implements MetricCollector<PaintMetrics> {
   #paintObserver: PerformanceObserver | null = null
   #resourceObserver: PerformanceObserver | null = null
   #layerObserver: MutationObserver | null = null
+  /** Entries before this timestamp belong to an earlier story or reset. */
+  #epochMs = 0
 
   start(): void {
+    this.#epochMs = performance.now()
+
     // Paint observer
     try {
       this.#paintObserver = new PerformanceObserver(list => {
-        this.#paintCount += list.getEntries().length
+        this.#paintCount += list.getEntries().filter(entry => entry.startTime >= this.#epochMs).length
       })
       this.#paintObserver.observe({type: 'paint', buffered: true})
     } catch {
@@ -73,6 +77,7 @@ export class PaintCollector implements MetricCollector<PaintMetrics> {
     try {
       this.#resourceObserver = new PerformanceObserver(list => {
         for (const entry of list.getEntries()) {
+          if (entry.startTime < this.#epochMs) continue
           if (entry.entryType === 'resource') {
             const resourceEntry = entry as PerformanceResourceTiming
             if (resourceEntry.initiatorType === 'script') {
@@ -109,6 +114,7 @@ export class PaintCollector implements MetricCollector<PaintMetrics> {
     this.#pendingChecks.clear()
     this.#pendingSubtrees = []
     this.#hasRemovals = false
+    this.#epochMs = performance.now()
     this.#cancelPendingScan()
     // Schedule a fresh full scan if tracking is active
     if (this.#layerObserver) {

--- a/packages/storybook-addon-performance-panel/core/preview-core.ts
+++ b/packages/storybook-addon-performance-panel/core/preview-core.ts
@@ -142,8 +142,7 @@ export class PerformanceMonitorCore {
     }
 
     const handleReset = () => {
-      this.manager.reset()
-      performanceStore.resetAll()
+      this.reset()
     }
 
     channel.on(PERF_EVENTS.REQUEST_METRICS, handleRequestMetrics)
@@ -197,6 +196,12 @@ export class PerformanceMonitorCore {
 
     this.containerCleanup?.()
     this.containerCleanup = null
+  }
+
+  /** Reset all collector and stored metrics without changing lifecycle state. */
+  reset(): void {
+    this.manager.reset()
+    performanceStore.resetAll()
   }
 
   /**

--- a/packages/storybook-addon-performance-panel/react/performance-decorator.tsx
+++ b/packages/storybook-addon-performance-panel/react/performance-decorator.tsx
@@ -153,7 +153,9 @@ export const PerformanceProvider = memo(function PerformanceProvider({
     const core = coreRef.current
     if (!enabled || !core) return
 
-    // Update storyId in case it changed (re-render with different story)
+    if (core.storyId !== storyId) {
+      core.reset()
+    }
     core.storyId = storyId
 
     core.start()

--- a/packages/storybook-addon-performance-panel/vitest.config.ts
+++ b/packages/storybook-addon-performance-panel/vitest.config.ts
@@ -19,8 +19,11 @@ export default defineConfig({
         },
       },
       {
+        optimizeDeps: {
+          include: ['vitest-browser-react'],
+        },
         test: {
-          include: ['**/*.browser.{test,spec}.ts'],
+          include: ['**/*.browser.{test,spec}.{ts,tsx}'],
           name: 'browser',
           browser: {
             enabled: true,


### PR DESCRIPTION
## Summary

Start the v1.2 stack by isolating buffered browser performance entries to the active story.

- filter buffered CLS, LoAF, Event Timing, FID, paint, resource, and Element Timing entries by collector start/reset epoch
- report Element Timing as elapsed story time instead of an absolute page timestamp
- prefer the story-local native interaction count, with legacy Chromium ID spacing only as a fallback
- add stale-entry and reset regression coverage

## Stack

1. **This PR**: story-scoped buffered metrics
2. #157: frame lifecycle and hidden-preview handling
3. #158: visibility-driven collection and live-update lifecycle

## Validation

- 54 test files / 759 tests across Chromium, Firefox, and WebKit
- `npm run tsc`
- `npm run lint` (one pre-existing unused suppression warning)