### PR TITLE
Fix Changesets workspace validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15250,6 +15250,7 @@
     },
     "packages/storybook-config": {
       "name": "@github-ui/storybook-config",
+      "version": "0.0.0",
       "dependencies": {
         "storybook": "^10.5.8"
       },

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@github-ui/storybook-config",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- add a version to the private `@github-ui/storybook-config` workspace
- keep the lockfile workspace metadata in sync
- allow Changesets to validate the dependency graph and publish the currently unpublished `1.2.0` release

## Validation

- `npx changeset status`
- `npm install --package-lock-only --ignore-scripts --offline`
- `npm run build`
- `npm test` (60 files, 840 tests)